### PR TITLE
Wrapper layout fixes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -899,7 +899,7 @@ section.post-menu-area {
 .alert,
 #share-link.visible,
 .wrap {
-  max-width: $V-page-max-width;
+  max-width: 1110px;
 }
 
 // custom ---------------------------------------------

--- a/common/common.scss
+++ b/common/common.scss
@@ -2228,7 +2228,7 @@ $q-background: rgba(contrast($text-base), 0.5) !default;
   -webkit-text-stroke: 0;
 }
 
-@if $rounded_borders == "true" {
+@if $rounded_interface_borders == "true" {
   #post_1 .contents,
   .nav-pills > li.active > a,
   .topic-map .buttons .btn,

--- a/common/common.scss
+++ b/common/common.scss
@@ -833,7 +833,7 @@ section.embedded-posts.top {
 }
 
 #main-outlet {
-  padding-top: 80px;
+  padding-top: 1.5em;
 }
 
 #post_1 .post-actions .post-action {

--- a/common/common.scss
+++ b/common/common.scss
@@ -98,7 +98,7 @@ $button-text-case: #{$button_text_case} !default;
 
 html {
   font-family: "Assistant", sans-serif;
-  background: #222;
+  background: #0A051E;
   font-size: 15px;
 }
 

--- a/settings.yml
+++ b/settings.yml
@@ -9,7 +9,7 @@ dark_background_overlay:
 rounded_borders:
   default: false
   description:
-    en: Enable rounded borders?
+    en: Enable rounded interface borders?
 button_text_case:
   default: uppercase
   type: enum
@@ -23,4 +23,4 @@ highlight_duration:
   min: 0.25
   max: 5
   description:
-    en: How long - in seconds - should the highlight last?
+    en: How long – in seconds – should the highlight last?

--- a/settings.yml
+++ b/settings.yml
@@ -6,7 +6,7 @@ dark_background_overlay:
   default: false
   description:
     en: Enable this if you've set a custom background above.
-rounded_borders:
+rounded_interface_borders:
   default: false
   description:
     en: Enable rounded interface borders?


### PR DESCRIPTION
Fixes to the wrapper layout. Introduces a fixed max-width so page content doesn't take up most of the screen, and reduce padding at the top of screen.

Changes the background color to a deep blue, similar to the initial prototype for Vincent II.

Miscellaneous tweaks, with renaming the rounded_borders variable and tweaking en-locale for grammar/clarity.