### PR TITLE
Remove rounded borders on bullet category style 

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1243,10 +1243,6 @@ a {
   right: 3px;
 }
 
-.badge-category-bg {
-  border-radius: 100vw;
-}
-
 .badge-wrapper.box span.badge-category-bg {
   border-radius: 0;
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1243,10 +1243,6 @@ a {
   right: 3px;
 }
 
-.badge-wrapper.box span.badge-category-bg {
-  border-radius: 0;
-}
-
 header.d-header.clearfix {
   border-bottom: 1px solid #555555;
 }


### PR DESCRIPTION
Applies to both parent and child categories.