### PR TITLE
Initial implementation of rounded_category_styles setting 

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -2282,3 +2282,10 @@ $q-background: rgba(contrast($text-base), 0.5) !default;
     margin-top: -10px;
   }
 }
+
+@if $rounded_category_styles == "true" {
+  /* Border radius for "bullet" category style */
+  .badge-wrapper.bullet span.badge-category-bg { border-radius: 50%; }
+  .badge-wrapper.bullet span.badge-category-parent-bg { border-radius: 50% 0 0 50%; }
+  .badge-wrapper.bullet span.badge-category-parent-bg + span.badge-category-bg { border-radius: 0 50% 50% 0; }
+}

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles? (Note: only affects “bullet” category style)"
+    en: "Enable rounded category styles? (Note: only affects ""bullet"" category style)"
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: Enable rounded category styles?
+    en: "Enable rounded category styles? (Note: only affects %25bullet%25 category style)"
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles? (Note: only affects " + "bullet" + " category style)"
+    en: "Enable rounded category styles? (Note: only affects 'bullet' category style)"
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -10,6 +10,10 @@ rounded_interface_borders:
   default: false
   description:
     en: Enable rounded interface borders?
+rounded_category_styles:
+  default: false
+  description:
+    en: Enable rounded category styles?
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles? (Note: only affects ""bullet"" category style)"
+    en: "Enable rounded category styles? (Note: only affects \"bullet\" category style)"
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles? (Note: only affects 'bullet' category style)"
+    en: "Enable rounded category styles? (Note: only affects “bullet” category style)"
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles? (Note: only affects %25bullet%25 category style)"
+    en: "Enable rounded category styles?\n(Note: only affects %25bullet%25 category style)"
 button_text_case:
   default: uppercase
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -13,7 +13,7 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles?\n(Note: only affects %25bullet%25 category style)"
+    en: "Enable rounded category styles? (Note: only affects " + "bullet" + " category style)"
 button_text_case:
   default: uppercase
   type: enum


### PR DESCRIPTION
- Defaults to false.
- In the future, it will add rounded borders to all category styles (bar, box, bullet).
- Currently, it only works with the "bullet" category style.