### PR TITLE
box_style_text-shadow setting

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -2283,6 +2283,14 @@ $q-background: rgba(contrast($text-base), 0.5) !default;
   }
 }
 
+@if $box_style_text-shadow == "true" {
+  /* Adds text-shadow to category names in their category badge style */
+  .badge-wrapper.box span.badge-category .category-name {
+    text-shadow: 0 0 3px black;
+    padding: 0px 0.5px;
+  }
+}
+
 @if $rounded_category_styles == "true" {
   /* "bar" category style */
   .badge-wrapper.bar span.badge-category-bg { border-radius: 5px; }
@@ -2296,5 +2304,4 @@ $q-background: rgba(contrast($text-base), 0.5) !default;
   .badge-wrapper.bullet span.badge-category-bg { border-radius: 50%; }
   .badge-wrapper.bullet span.badge-category-parent-bg { border-radius: 50% 0 0 50%; }
   .badge-wrapper.bullet span.badge-category-parent-bg + span.badge-category-bg { border-radius: 0 50% 50% 0; }
-  
 }

--- a/settings.yml
+++ b/settings.yml
@@ -5,7 +5,7 @@ theme_background:
 dark_background_overlay:
   default: false
   description:
-    en: Enable this if you've set a custom background above.
+    en: "Enable this if you've set a custom background above."
 rounded_interface_borders:
   default: false
   description:
@@ -13,7 +13,11 @@ rounded_interface_borders:
 rounded_category_styles:
   default: false
   description:
-    en: "Enable rounded category styles? (Note: only affects \"bullet\" category style)"
+    en: Enable rounded category styles?
+box_style_text-shadow:
+  default: false
+  description:
+    en: Enable a text-shadow effect on category names, when using the box category style?
 button_text_case:
   default: uppercase
   type: enum


### PR DESCRIPTION
Toggle this setting on to enable a text-shadow effect on the category names when using the "box" category badge style.