### PR TITLE
Redundancy, consistency, and plugin support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -887,15 +887,6 @@ section.post-menu-area {
   width: 100%;
 }
 
-// max-width 95vw -------------------------------------
-
-.main-content,
-.alert,
-#share-link.visible,
-.wrap {
-  max-width: 1110px;
-}
-
 // custom ---------------------------------------------
 
 #topic-title .title-wrapper,
@@ -906,10 +897,6 @@ section.post-menu-area {
 
 .embedded-posts.top {
   width: 690px;
-}
-
-.wrap {
-  width: 1110px;
 }
 
 #reply-control .d-editor-preview img:not(.thumbnail):not(.emoji),

--- a/common/common.scss
+++ b/common/common.scss
@@ -918,6 +918,10 @@ section.post-menu-area {
   height: auto;
 }
 
+ol.category-breadcrumb {
+  min-height: 36px;
+}
+
 // Animation  ---------------------------------------------------------------------------------
 
 .topic-list > .topic-list-body > tr.highlighted,

--- a/common/common.scss
+++ b/common/common.scss
@@ -597,6 +597,7 @@ ol.category-breadcrumb {
 
 // Top zero -----------------------------------------
 
+.dashboard.admin-contents, .dashboard-next.admin-contents,
 .user-main .about.collapsed-info .details,
 #user-card .user-card-avatar,
 .top-lists,

--- a/common/common.scss
+++ b/common/common.scss
@@ -2169,14 +2169,14 @@ $q-background: rgba(contrast($text-base), 0.5) !default;
 
 // Discourse Solved (plugin) https://github.com/discourse/discourse-solved
 li.solved-status-filter details.solved-status-filter summary {
-    background: none;
-    border: none;
+    background: none !important;
+    border: none !important;
 }
 
 // Unanswered Filter (theme component) https://github.com/discourse/discourse-unanswered-filter
 .unanswered-filter-connector div .topic-unanswered-filter-dropdown summary {
-    background: none;
-    border: none;
+    background: none !important;
+    border: none !important;
 }
 
 // Additional configuration settings -----------------------------------------------------------------------------

--- a/common/common.scss
+++ b/common/common.scss
@@ -2165,6 +2165,22 @@ $q-background: rgba(contrast($text-base), 0.5) !default;
   -webkit-text-stroke: 0;
 }
 
+// Plugin and Theme Component support -----------------------------------------------------------------------------
+
+// Discourse Solved (plugin) https://github.com/discourse/discourse-solved
+li.solved-status-filter details.solved-status-filter summary {
+    background: none;
+    border: none;
+}
+
+// Unanswered Filter (theme component) https://github.com/discourse/discourse-unanswered-filter
+.unanswered-filter-connector div .topic-unanswered-filter-dropdown summary {
+    background: none;
+    border: none;
+}
+
+// Additional configuration settings -----------------------------------------------------------------------------
+
 @if $rounded_interface_borders == "true" {
   #post_1 .contents,
   .nav-pills > li.active > a,


### PR DESCRIPTION
- Set a minimum height for category labels on nav-pills, which matches the minimum height of the button icons also on the nav-pills. This fixes an issue where the category label can end up being smaller than the nav-pills, which looks bad.

- Removes some redundant styling to elements like the `.wrap`.

- Removes the top margin from the admin dashboard, making it more consistent stylistically to all the other admin tabs.

- Adds support for the Discourse Solved plugin, and Unanswered Filter theme component. The support includes styling to make them appear similar to other elements on the nav-pills.