### PR TITLE
version 1.3.2

### DIFF
--- a/about.json
+++ b/about.json
@@ -2,7 +2,7 @@
   "name": "Vincent II",
   "about_url": "https://github.com/MoltonMontro/discourse-vincent2-theme/blob/main/README.md",
   "license_url": "https://github.com/MoltonMontro/discourse-vincent2-theme/blob/main/LICENSE",
-  "theme_version": "1.3.1",
+  "theme_version": "1.3.2",
   "assets": {
     "vincent-background": "assets/vincent-background.svg"
   },

--- a/common/common.scss
+++ b/common/common.scss
@@ -1249,10 +1249,9 @@ a {
   right: 3px;
 }
 
-/* Width of "bar" category style -- default is unsymmetrical and ugly. */
-.badge-wrapper.bar span.badge-category-bg { width: 3px; }
-.badge-wrapper.bar span.badge-category-parent-bg,
-.badge-wrapper.bar span.badge-category-parent-bg + span.badge-category-bg { width: 3px; }
+  .badge-wrapper.bar span.badge-category-bg,
+  .badge-wrapper.bar span.badge-category-parent-bg,
+  .badge-wrapper.bar span.badge-category-parent-bg + span.badge-category-bg { width: 3px; } // default width is unsymmetrical and ugly
 
 header.d-header.clearfix, .published-page-header {
   border-bottom: 1px solid #555555;

--- a/common/common.scss
+++ b/common/common.scss
@@ -353,8 +353,7 @@ button.ok:hover {
 .select-kit.combo-box.tag-drop .tag-drop-header,
 .select-kit.combo-box.category-drop .category-drop-header,
 li.toggle-maximize a,
-a.mention,
-a.mention-group,
+a.hashtag-cooked,
 .user-badge,
 #user-card.show-badges .more-user-badges,
 .list-controls .category-breadcrumb li.bullet > .dropdown-header,
@@ -669,8 +668,7 @@ ul.subcat-list,
 // padding zero -------------------------------------
 
 .topic-users > .inline,
-a.mention,
-a.mention-group,
+a.hashtag-cooked,
 .cooked .lightbox-wrapper,
 .topic-post article.boxed,
 .topic-avatar,
@@ -1083,11 +1081,8 @@ a {
   &:hover {
     color: invert-contrast($text-base) $i;
   }
-  &.mention {
+  &.hashtag-cooked {
     color: adjust-hue($link-color, 10deg);
-  }
-  &.mention-group {
-    color: adjust-hue($link-color, -10deg);
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -513,6 +513,17 @@ img.avatar,
   border-width: 1px;
 }
 
+// outline ---------------------------
+
+.group-card, .user-card { // remove outline color from cards, which always appear on every page
+	outline-color: rgba(0,0,0,0);
+}
+
+.user-card .card-content, .group-card .card-content { // re-add outline to cards, but only .card-content
+	outline-width: 2px;
+	outline-style: solid;
+}
+
 // Margins ------------------------------------------------------------------------------------
 
 // 0 auto ------------------------------------------

--- a/common/common.scss
+++ b/common/common.scss
@@ -337,6 +337,10 @@ button.ok:hover {
     background-color: #115d7a;
 }
 
+a.hashtag-cooked { // inline mentions
+	background: rgba(50,50,50,0.5); // maybe different bg color
+}
+
 // background none ------------------------------
 
 .nav-pills > li:not(.active) > a:hover,
@@ -353,7 +357,6 @@ button.ok:hover {
 .select-kit.combo-box.tag-drop .tag-drop-header,
 .select-kit.combo-box.category-drop .category-drop-header,
 li.toggle-maximize a,
-a.hashtag-cooked,
 .user-badge,
 #user-card.show-badges .more-user-badges,
 .list-controls .category-breadcrumb li.bullet > .dropdown-header,

--- a/common/common.scss
+++ b/common/common.scss
@@ -516,7 +516,7 @@ img.avatar,
 // outline ---------------------------
 
 .group-card, .user-card { // remove outline color from cards, which always appear on every page
-	outline-color: rgba(0,0,0,0);
+	outline-color: rgba(0,0,0,0) $i;
 }
 
 .user-card .card-content, .group-card .card-content { // re-add outline to cards, but only .card-content

--- a/common/common.scss
+++ b/common/common.scss
@@ -671,7 +671,6 @@ ul.subcat-list,
 // padding zero -------------------------------------
 
 .topic-users > .inline,
-a.hashtag-cooked,
 .cooked .lightbox-wrapper,
 .topic-post article.boxed,
 .topic-avatar,
@@ -853,6 +852,9 @@ a.expand-hidden {
 	padding-bottom: 1.1em;
 }
 
+a.hashtag-cooked { // inline mentions
+	padding: 0 0.3em 0em;
+}
 
 // Display and positioning --------------------------------------------------------------------
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -1087,7 +1087,7 @@ a {
     color: invert-contrast($text-base) $i;
   }
   &.hashtag-cooked {
-    color: adjust-hue($link-color, 10deg);
+    color: adjust-hue($link-color, -10deg);
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -1086,9 +1086,6 @@ a {
   &:hover {
     color: invert-contrast($text-base) $i;
   }
-  &.hashtag-cooked {
-    color: adjust-hue($link-color, -10deg);
-  }
 }
 
 .user-main .staff-counters a {


### PR DESCRIPTION
- Simplify .badge-wrapper.bar code for width
- Replaced styling of a.mention & a.mention-group w/ a.hashtag-cooked
- custom bg-color for inline mentions
- Custom padding for a.hashtag-cooked 
- Remove adjust-hue for inline mentions
- Bumped version to 1.3.2
- Card outlines